### PR TITLE
Support ranges that go to the very end of the day

### DIFF
--- a/lib/working_hours/config.rb
+++ b/lib/working_hours/config.rb
@@ -5,7 +5,7 @@ module WorkingHours
 
   class Config
 
-    TIME_FORMAT = /\A([0-1][0-9]|2[0-3]):([0-5][0-9])\z/
+    TIME_FORMAT = /\A(\d{2}):([0-5][0-9])\z/
     DAYS_OF_WEEK = [:sun, :mon, :tue, :wed, :thu, :fri, :sat]
 
     class << self
@@ -111,6 +111,8 @@ module WorkingHours
               raise InvalidConfiguration.new "Invalid time: #{start} - must be 'HH:MM'"
             elsif not finish =~ TIME_FORMAT
               raise InvalidConfiguration.new "Invalid time: #{finish} - must be 'HH:MM'"
+            elsif compile_time(finish) > 24 * 60 * 60
+              raise InvalidConfiguration.new "Invalid time: #{finish} - must be a valid timestamp"
             elsif start >= finish
               raise InvalidConfiguration.new "Invalid range: #{start} => #{finish} - ends before it starts"
             elsif last_time and start < last_time

--- a/spec/working_hours/config_spec.rb
+++ b/spec/working_hours/config_spec.rb
@@ -86,8 +86,14 @@ describe WorkingHours::Config do
         }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid time: 8:0 - must be 'HH:MM'")
 
         expect {
-          WorkingHours::Config.working_hours = {:mon => {'08:00' => '24:00'}}
-        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid time: 24:00 - must be 'HH:MM'")
+          WorkingHours::Config.working_hours = {:mon => {'08:00' => '21:90'}}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid time: 21:90 - must be 'HH:MM'")
+      end
+
+      it 'rejects invalid timestamps' do
+        expect {
+          WorkingHours::Config.working_hours = {:mon => {'08:00' => '24:01'}}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid time: 24:01 - must be a valid timestamp")
       end
 
       it 'rejects invalid range' do


### PR DESCRIPTION
Currently, only time ranges that end at 11:59 or before are accepted. This makes it impossible to define ranges that include the last minute of the day (23:59 - 24:00).

With this change, 24:00 is now a valid ending time, but times above 24:00 are still rejected as invalid.
