### PR TITLE
sorts week config hash on setter

### DIFF
--- a/lib/working_hours/config.rb
+++ b/lib/working_hours/config.rb
@@ -16,6 +16,7 @@ module WorkingHours
 
       def working_hours=(val)
         validate_working_hours! val
+        val = sort_working_hours val
         config[:working_hours] = val
         config.delete :precompiled
       end
@@ -144,6 +145,14 @@ module WorkingHours
           raise InvalidConfiguration.new "Invalid time zone: #{zone.inspect} - must be String or ActiveSupport::TimeZone"
         end
         res
+      end
+
+      def sort_working_hours week
+        new_hash = {}
+        week.each do |day,config|
+          new_hash[day] = Hash[config.sort]
+        end
+        new_hash
       end
 
     end

--- a/spec/working_hours/config_spec.rb
+++ b/spec/working_hours/config_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rspec-api-matchers'
 
 describe WorkingHours::Config do
 
@@ -8,6 +9,26 @@ describe WorkingHours::Config do
 
     it 'has a default config' do
       expect(config).to be_kind_of(Hash)
+    end
+
+    it 'sorts the config hash' do
+      include RSpecApi::Matchers::Sort
+      not_sorted_hash = {
+        :tue => {'13:00' => '17:00', '09:00' => '12:00'},
+        :wed => {'09:00' => '12:00', '13:00' => '17:00'},
+        :thu => {'09:00' => '12:00', '13:00' => '17:00'},
+        :fri => {'13:00' => '17:00', '09:00' => '12:00'},
+        :sat => {'10:00' => '15:00'}
+      }
+      sorted_hash = {
+        :tue => {'09:00' => '12:00', '13:00' => '17:00'},
+        :wed => {'09:00' => '12:00', '13:00' => '17:00'},
+        :thu => {'09:00' => '12:00', '13:00' => '17:00'},
+        :fri => {'09:00' => '12:00', '13:00' => '17:00'},
+        :sat => {'10:00' => '15:00'}
+      }
+      WorkingHours::Config.working_hours = not_sorted_hash
+      expect(sorted_hash).to eql WorkingHours::Config.working_hours
     end
 
     it 'is thread safe' do

--- a/working_hours.gemspec
+++ b/working_hours.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'timecop'
+  spec.add_development_dependency 'rspec-api-matchers'
 end


### PR DESCRIPTION
Discovered accidentally that, if the working_hours hash config has many "ins" and "outs", the algorithm does not calculate working hours successfully. to avoid failure on the algorithm, working_hours setter sorts the hash. rspec included on this commit.
