### PR TITLE
Make working hours really thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
-[Compare master with v1.1.3](https://github.com/intrepidd/working_hours/compare/v1.1.3...master)
+[Compare master with v1.1.4](https://github.com/intrepidd/working_hours/compare/v1.1.4...master)
+
+# v1.1.4
+* Fix thread safety - [#36](https://github.com/Intrepidd/working_hours/pull/36)
 
 # v1.1.3
 * Fixed warnings with Ruby 2.4.0+ - [#32](https://github.com/Intrepidd/working_hours/pull/32)

--- a/lib/working_hours/config.rb
+++ b/lib/working_hours/config.rb
@@ -89,7 +89,7 @@ module WorkingHours
       private
 
       def config
-        Thread.current[:working_hours] ||= global_config
+        Thread.current[:working_hours] ||= global_config.dup
       end
 
       def global_config

--- a/lib/working_hours/version.rb
+++ b/lib/working_hours/version.rb
@@ -1,3 +1,3 @@
 module WorkingHours
-  VERSION = "1.1.3"
+  VERSION = "1.1.4"
 end


### PR DESCRIPTION
I found out that the working hours gem is actually not thread safe because the thread local config variable is initialized by a **hash reference**, so every thread actually hold the same config variable.

As far as I can see, the code only modifies the config hash at its first level, so a simple `dup` is enough to fix this issue.