### PR TITLE
New config option - holiday hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ end
 - ``holidays``
 - ``time_zone``
 
+### Holiday hours
+Sometimes you need to configure different working hours as a one-off, e.g. the working day might end earlier on Christmas Eve.
+
+You can configure this with the `holiday_hours` option, either as an override on the existing working hours, or as a set of hours that *are* being worked on a holiday day.
+
+If *any* hours are set for a calendar day in `holiday_hours`, then the `working_hours` for that day will be ignored, and only the entries in `holiday_hours` taken into consideration.
+
+```ruby
+# Configure holiday hours
+WorkingHours::Config.holiday_hours = {Date.new(2020, 12, 24) => {'09:00' => '12:00', '13:00' => '15:00'}}
+```
 
 ## No core extensions / monkey patching
 

--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -96,7 +96,7 @@ module WorkingHours
         # find next working range after time
         time_in_day = time.seconds_since_midnight
         time = time.beginning_of_day
-        (config[:working_hours][time.wday] || {}).each do |from, to|
+        (config[:holiday_hours][time.to_date.to_s] || config[:working_hours][time.wday] || {}).each do |from, to|
           return time + to if time_in_day >= from and time_in_day < to
           return time + to if from >= time_in_day
         end
@@ -127,7 +127,7 @@ module WorkingHours
         end
         # find last working range before time
         time_in_day = time.seconds_since_midnight
-        (config[:working_hours][time.wday] || {}).reverse_each do |from, to|
+        (config[:holiday_hours][time.to_date.to_s] || config[:working_hours][time.wday] || {}).reverse_each do |from, to|
           # round is used to suppress miliseconds hack from `end_of_day`
           return time if time_in_day > from and time_in_day <= to
           return (time - (time_in_day - to)) if to <= time_in_day
@@ -148,7 +148,7 @@ module WorkingHours
       time = in_config_zone(time, config: config)
       return false if not working_day?(time, config: config)
       time_in_day = time.seconds_since_midnight
-      config[:working_hours][time.wday].each do |from, to|
+      (config[:holiday_hours][time.to_date.to_s] || config[:working_hours][time.wday]).each do |from, to|
         return true if time_in_day >= from and time_in_day < to
       end
       false

--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -99,7 +99,6 @@ module WorkingHours
         end
         # find next working range after time
         time_in_day = time.seconds_since_midnight
-        time = time.beginning_of_day
         (config[:holiday_hours][time.to_date.to_s] || config[:working_hours][time.wday]).each do |from, to|
           return move_time_of_day(time, to) if time_in_day < to
         end
@@ -131,7 +130,6 @@ module WorkingHours
         # find last working range before time
         time_in_day = time.seconds_since_midnight
         (config[:holiday_hours][time.to_date.to_s] || config[:working_hours][time.wday]).reverse_each do |from, to|
-          # round is used to suppress miliseconds hack from `end_of_day`
           return time if time_in_day > from and time_in_day <= to
           return move_time_of_day(time, to) if to <= time_in_day
         end

--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -80,7 +80,8 @@ module WorkingHours
         end
         # find first working range after time
         time_in_day = time.seconds_since_midnight
-        (config[:holiday_hours][time.to_date] || config[:working_hours][time.wday]).each do |from, to|
+        
+        working_hours_for(time, config: config).each do |from, to|
           return time if time_in_day >= from and time_in_day < to
           return move_time_of_day(time, from) if from >= time_in_day
         end
@@ -99,7 +100,7 @@ module WorkingHours
         end
         # find next working range after time
         time_in_day = time.seconds_since_midnight
-        (config[:holiday_hours][time.to_date] || config[:working_hours][time.wday]).each do |from, to|
+        working_hours_for(time, config: config).each do |from, to|
           return move_time_of_day(time, to) if time_in_day < to
         end
         # if none is found, go to next day and loop
@@ -129,7 +130,7 @@ module WorkingHours
         end
         # find last working range before time
         time_in_day = time.seconds_since_midnight
-        (config[:holiday_hours][time.to_date] || config[:working_hours][time.wday]).reverse_each do |from, to|
+        working_hours_for(time, config: config).reverse_each do |from, to|
           return time if time_in_day > from and time_in_day <= to
           return move_time_of_day(time, to) if to <= time_in_day
         end
@@ -151,7 +152,7 @@ module WorkingHours
       time = in_config_zone(time, config: config)
       return false if not working_day?(time, config: config)
       time_in_day = time.seconds_since_midnight
-      (config[:holiday_hours][time.to_date] || config[:working_hours][time.wday]).each do |from, to|
+      working_hours_for(time, config: config).each do |from, to|
         return true if time_in_day >= from and time_in_day < to
       end
       false
@@ -246,6 +247,10 @@ module WorkingHours
       when DateTime then time.to_datetime
       else time
       end
+    end
+
+    def working_hours_for(time, config:)
+      config[:holiday_hours][time.to_date] || config[:working_hours][time.wday]
     end
   end
 end

--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -254,17 +254,12 @@ module WorkingHours
         next unless time.to_date == date
   
         hours.each do |start_time, end_time|
-          if hour_to_seconds(time) >= start_time && hour_to_seconds(time) <= end_time
+          if time.seconds_since_midnight >= start_time && time.seconds_since_midnight <= end_time
             matched_hours << { start_time => end_time}
           end
         end
       end
       matched_hours.any?
-    end
-
-    def hour_to_seconds(time)
-      start_of_day = time.at_beginning_of_day
-      time.to_i - start_of_day.to_i
     end
   end
 end

--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -80,7 +80,7 @@ module WorkingHours
         end
         # find first working range after time
         time_in_day = time.seconds_since_midnight
-        (config[:holiday_hours][time.to_date.to_s] || config[:working_hours][time.wday]).each do |from, to|
+        (config[:holiday_hours][time.to_date] || config[:working_hours][time.wday]).each do |from, to|
           return time if time_in_day >= from and time_in_day < to
           return move_time_of_day(time, from) if from >= time_in_day
         end
@@ -99,7 +99,7 @@ module WorkingHours
         end
         # find next working range after time
         time_in_day = time.seconds_since_midnight
-        (config[:holiday_hours][time.to_date.to_s] || config[:working_hours][time.wday]).each do |from, to|
+        (config[:holiday_hours][time.to_date] || config[:working_hours][time.wday]).each do |from, to|
           return move_time_of_day(time, to) if time_in_day < to
         end
         # if none is found, go to next day and loop
@@ -129,7 +129,7 @@ module WorkingHours
         end
         # find last working range before time
         time_in_day = time.seconds_since_midnight
-        (config[:holiday_hours][time.to_date.to_s] || config[:working_hours][time.wday]).reverse_each do |from, to|
+        (config[:holiday_hours][time.to_date] || config[:working_hours][time.wday]).reverse_each do |from, to|
           return time if time_in_day > from and time_in_day <= to
           return move_time_of_day(time, to) if to <= time_in_day
         end
@@ -151,7 +151,7 @@ module WorkingHours
       time = in_config_zone(time, config: config)
       return false if not working_day?(time, config: config)
       time_in_day = time.seconds_since_midnight
-      (config[:holiday_hours][time.to_date.to_s] || config[:working_hours][time.wday]).each do |from, to|
+      (config[:holiday_hours][time.to_date] || config[:working_hours][time.wday]).each do |from, to|
         return true if time_in_day >= from and time_in_day < to
       end
       false
@@ -251,7 +251,7 @@ module WorkingHours
     def holiday_hour?(time, config: nil)
       matched_hours = []
       config[:holiday_hours].each do |date, hours|
-        next unless time.to_date.to_s == date
+        next unless time.to_date == date
   
         hours.each do |start_time, end_time|
           if hour_to_seconds(time) >= start_time && hour_to_seconds(time) <= end_time

--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -40,7 +40,7 @@ module WorkingHours
         time = advance_to_working_time(time, config: config)
         # look at working ranges
         time_in_day = time.seconds_since_midnight
-        config[:working_hours][time.wday].each do |from, to|
+        working_hours_for(time, config: config).each do |from, to|
           if time_in_day >= from and time_in_day < to
             # take all we can
             take = [to - time_in_day, seconds].min
@@ -56,7 +56,8 @@ module WorkingHours
         time = return_to_exact_working_time(time, config: config)
         # look at working ranges
         time_in_day = time.seconds_since_midnight
-        config[:working_hours][time.wday].reverse_each do |from, to|
+        
+        working_hours_for(time, config: config).reverse_each do |from, to|
           if time_in_day > from and time_in_day <= to
             # take all we can
             take = [time_in_day - from, -seconds].min

--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -143,7 +143,7 @@ module WorkingHours
       time = in_config_zone(time, config: config)
 
       (config[:working_hours][time.wday].present? && !config[:holidays].include?(time.to_date)) ||
-        holiday_hour?(time, config: config)
+        config[:holiday_hours].include?(time.to_date)
     end
 
     def in_working_hours? time, config: nil
@@ -246,20 +246,6 @@ module WorkingHours
       when DateTime then time.to_datetime
       else time
       end
-    end
-
-    def holiday_hour?(time, config: nil)
-      matched_hours = []
-      config[:holiday_hours].each do |date, hours|
-        next unless time.to_date == date
-  
-        hours.each do |start_time, end_time|
-          if time.seconds_since_midnight >= start_time && time.seconds_since_midnight <= end_time
-            matched_hours << { start_time => end_time}
-          end
-        end
-      end
-      matched_hours.any?
     end
   end
 end

--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -187,7 +187,7 @@ module WorkingHours
           from_was = from
           # look at working ranges
           time_in_day = from.seconds_since_midnight
-          config[:working_hours][from.wday].each do |begins, ends|
+          working_hours_for(from, config: config).each do |begins, ends|
             if time_in_day >= begins and time_in_day < ends
               if (to - from) > (ends - time_in_day)
                 # take all the range and continue

--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -76,7 +76,7 @@ module WorkingHours
         end
         # find first working range after time
         time_in_day = time.seconds_since_midnight
-        (config[:working_hours][time.wday] || {}).each do |from, to|
+        (config[:holiday_hours][time.to_date.to_s] || config[:working_hours][time.wday] || {}).each do |from, to|
           return time if time_in_day >= from and time_in_day < to
           return time + (from - time_in_day) if from >= time_in_day
         end
@@ -222,6 +222,5 @@ module WorkingHours
       else time
       end
     end
-
   end
 end

--- a/lib/working_hours/config.rb
+++ b/lib/working_hours/config.rb
@@ -14,7 +14,7 @@ module WorkingHours
       end
 
       def working_hours=(val)
-        validate_hours! val, type: :working_hours
+        validate_working_hours! val
         config[:working_hours] = val
         global_config[:working_hours] = val
         config.delete :precompiled
@@ -36,7 +36,7 @@ module WorkingHours
       end
 
       def holiday_hours=(val)
-        validate_hours! val, type: :holiday_hours
+        validate_holiday_hours! val
         config[:holiday_hours] = val
         global_config[:holiday_hours] = val
         config.delete :precompiled
@@ -57,8 +57,8 @@ module WorkingHours
         end
 
         config[:precompiled] ||= begin
-          validate_hours! config[:working_hours], type: :working_hours
-          validate_hours! config[:holiday_hours], type: :holiday_hours
+          validate_working_hours! config[:working_hours]
+          validate_holiday_hours! config[:holiday_hours]
           validate_holidays! config[:holidays]
           validate_time_zone! config[:time_zone]
           compiled = { working_hours: Array.new(7) { Hash.new }, holiday_hours: {} }
@@ -146,14 +146,7 @@ module WorkingHours
         time
       end
 
-      def validate_hours! dates, type:
-        case type
-        when :working_hours
-          validate_working_hours! dates
-        when :holiday_hours
-          validate_holiday_hours! dates
-        end
-        
+      def validate_hours! dates
         dates.each do |day, hours|
           if not hours.is_a? Hash
             raise InvalidConfiguration.new "Invalid type for `#{day}`: #{hours.class} - must be Hash"
@@ -185,12 +178,14 @@ module WorkingHours
         if (invalid_keys = (week.keys - DAYS_OF_WEEK)).any?
           raise InvalidConfiguration.new "Invalid day identifier(s): #{invalid_keys.join(', ')} - must be 3 letter symbols"
         end
+        validate_hours!(week)
       end
 
       def validate_holiday_hours! days
-        if (invalid_keys = (days.keys.select{ |day| day.class.to_s != 'Date' })).any?
+        if (invalid_keys = (days.keys.reject{ |day| day.is_a?(Date) })).any?
           raise InvalidConfiguration.new "Invalid day identifier(s): #{invalid_keys.join(', ')} - must be a Date object"
         end
+        validate_hours!(days)
       end
 
       def validate_holidays! holidays

--- a/lib/working_hours/config.rb
+++ b/lib/working_hours/config.rb
@@ -177,13 +177,11 @@ module WorkingHours
         end
       end
 
-      def validate_holiday_hours! week
-        begin
-          (week.keys.select { |k| Date.parse(k) })
-        rescue => ex
-          raise InvalidConfiguration.new "Invalid day identifier(s): Must be in the format 'YYYY-MM-DD'"
+      def validate_holiday_hours! days
+        if (invalid_keys = (days.keys.select{ |day| day.class.to_s != 'Date' })).any?
+          raise InvalidConfiguration.new "Invalid day identifier(s): #{invalid_keys.join(', ')} - must be a Date object"
         end
-        week.each do |day, hours|
+        days.each do |day, hours|
           if not hours.is_a? Hash
             raise InvalidConfiguration.new "Invalid type for `#{day}`: #{hours.class} - must be Hash"
           elsif hours.empty?

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -137,7 +137,7 @@ describe WorkingHours::Computation do
 
       context 'with a later starting hour' do
         before do
-          WorkingHours::Config.holiday_hours = { '2019-12-27' => { '10:00' => '18:00' } }
+          WorkingHours::Config.holiday_hours = { Date.new(2019, 12, 27) => { '10:00' => '18:00' } }
         end
 
         it 'adds working seconds' do
@@ -153,7 +153,7 @@ describe WorkingHours::Computation do
 
       context 'with an earlier ending hour' do
         before do
-          WorkingHours::Config.holiday_hours = { '2019-12-27' => { '08:00' => '17:00' } }
+          WorkingHours::Config.holiday_hours = { Date.new(2019, 12, 27) => { '08:00' => '17:00' } }
         end
 
         it 'adds working seconds' do
@@ -213,7 +213,7 @@ describe WorkingHours::Computation do
 
     it 'jumps outside holiday hours' do
       WorkingHours::Config.working_hours = { fri: { '08:00' => '18:00' } }
-      WorkingHours::Config.holiday_hours = { '2019-12-27' => { '10:00' => '18:00' } }
+      WorkingHours::Config.holiday_hours = { Date.new(2019, 12, 27) => { '10:00' => '18:00' } }
       expect(advance_to_working_time(Time.utc(2019, 12, 27, 9))).to eq(Time.utc(2019, 12, 27, 10))
     end
 
@@ -355,12 +355,12 @@ describe WorkingHours::Computation do
       end
 
       it 'takes into account reduced holiday closing' do
-        WorkingHours::Config.holiday_hours = { '2019-12-27' => { '10:00' => '17:00' } }
+        WorkingHours::Config.holiday_hours = { Date.new(2019, 12, 27) => { '10:00' => '17:00' } }
         expect(advance_to_closing_time(Time.new(2019, 12, 26, 20))).to eq(Time.new(2019, 12, 27, 17))
       end
 
       it 'takes into account extended holiday closing' do
-        WorkingHours::Config.holiday_hours = { '2019-12-26' => { '10:00' => '21:00' } }
+        WorkingHours::Config.holiday_hours = { Date.new(2019, 12, 26) => { '10:00' => '21:00' } }
         expect(advance_to_closing_time(Time.new(2019, 12, 26, 20))).to eq(Time.new(2019, 12, 26, 21))
       end
     end
@@ -576,7 +576,7 @@ describe WorkingHours::Computation do
     context 'with holiday hours' do
       before do
         WorkingHours::Config.working_hours = { thu: { '08:00' => '18:00' }, fri: { '08:00' => '18:00' } }
-        WorkingHours::Config.holiday_hours = { '2019-12-27' => { '10:00' => '20:00' } }
+        WorkingHours::Config.holiday_hours = { Date.new(2019, 12, 27) => { '10:00' => '20:00' } }
       end
 
       it 'returns true during working hours' do
@@ -784,7 +784,7 @@ describe WorkingHours::Computation do
     context 'with holiday hours' do
       before do
         WorkingHours::Config.working_hours = { mon: { '08:00' => '18:00' }, tue: { '08:00' => '18:00' } }
-        WorkingHours::Config.holiday_hours = { '2014-04-07' => { '10:00' => '12:00', '14:00' => '18:00' } }
+        WorkingHours::Config.holiday_hours = { Date.new(2014, 4, 7) => { '10:00' => '12:00', '14:00' => '18:00' } }
       end
 
       context 'time is before the start of holiday hours' do

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -149,6 +149,13 @@ describe WorkingHours::Computation do
           time = Time.utc(2019, 12, 27, 9)
           expect(add_seconds(time, -120)).to eq(Time.utc(2019, 12, 26, 17, 58))
         end
+
+        context 'working back from working hours' do
+          it 'moves to the previous working day' do
+            time = Time.utc(2019, 12, 27, 11)
+            expect(add_seconds(time, -2.hours)).to eq(Time.utc(2019, 12, 26, 17))
+          end
+        end
       end
 
       context 'with an earlier ending hour' do
@@ -164,6 +171,13 @@ describe WorkingHours::Computation do
         it 'removes working seconds' do
           time = Time.utc(2019, 12, 27, 18)
           expect(add_seconds(time, -120)).to eq(Time.utc(2019, 12, 27, 16, 58))
+        end
+
+        context 'working forward from working hours' do
+          it 'moves to the next working day' do
+            time = Time.utc(2019, 12, 27, 16)
+            expect(add_seconds(time, 2.hours)).to eq(Time.utc(2020, 1, 2, 9))
+          end
         end
       end
 
@@ -181,6 +195,20 @@ describe WorkingHours::Computation do
         it 'removes working seconds' do
           time = Time.utc(2019, 12, 27, 14)
           expect(add_seconds(time, -120)).to eq(Time.utc(2019, 12, 27, 11, 58))
+        end
+
+        context 'from morning to afternoon' do
+          it 'takes into account the additional hour for lunch set in `holiday_hours`' do
+            time = Time.utc(2019, 12, 27, 10)
+            expect(add_seconds(time, 4.hours)).to eq(Time.utc(2019, 12, 27, 16))
+          end
+        end
+
+        context 'from afternoon to morning' do
+          it 'takes into account the additional hour for lunch set in `holiday_hours`' do
+            time = Time.utc(2019, 12, 27, 16)
+            expect(add_seconds(time, -4.hours)).to eq(Time.utc(2019, 12, 27, 10))
+          end
         end
       end
     end

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -829,7 +829,7 @@ describe WorkingHours::Computation do
     context 'with holiday hours' do
       before do
         WorkingHours::Config.working_hours = { mon: { '08:00' => '18:00' }, tue: { '08:00' => '18:00' } }
-        WorkingHours::Config.holiday_hours = { Date.new(2014, 4, 7) => { '10:00' => '12:00', '14:00' => '18:00' } }
+        WorkingHours::Config.holiday_hours = { Date.new(2014, 4, 7) => { '10:00' => '12:00', '14:00' => '17:00' } }
       end
 
       context 'time is before the start of holiday hours' do
@@ -856,6 +856,33 @@ describe WorkingHours::Computation do
             Time.utc(2014, 4, 7, 19),
             Time.utc(2014, 4, 7, 20)
           )).to eq(0)
+        end
+      end
+
+      context 'time is before the start of the holiday hours' do
+        it 'does not count holiday hours as working time' do
+          expect(working_time_between(
+            Time.utc(2014, 4, 7, 9),
+            Time.utc(2014, 4, 7, 12)
+          )).to eq(7200)
+        end
+      end
+
+      context 'time crosses overridden holiday hours at midday' do
+        it 'does not count holiday hours as working time' do
+          expect(working_time_between(
+            Time.utc(2014, 4, 7, 9),
+            Time.utc(2014, 4, 7, 14)
+          )).to eq(7200)
+        end
+      end
+
+      context 'time crosses overridden holiday hours at midday' do
+        it 'does not count holiday hours as working time' do
+          expect(working_time_between(
+            Time.utc(2014, 4, 7, 12),
+            Time.utc(2014, 4, 7, 18)
+          )).to eq(10800)
         end
       end
     end

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -111,7 +111,7 @@ describe WorkingHours::Computation do
       expect(add_seconds(time, 120)).to eq(Time.utc(1991, 11, 18, 9, 1, 42))
     end
 
-    it 'Calls precompiled only once' do
+    it 'calls precompiled only once' do
       precompiled = WorkingHours::Config.precompiled
       expect(WorkingHours::Config).to receive(:precompiled).once.and_return(precompiled) # in_config_zone and add_seconds
       time = Time.utc(1991, 11, 15, 16, 59, 42) # Friday
@@ -562,7 +562,7 @@ describe WorkingHours::Computation do
         expect(in_working_hours?(Time.utc(2019, 12, 26, 9))).to be(true)
         expect(in_working_hours?(Time.utc(2019, 12, 27, 19))).to be(true)
       end
-  
+
       it 'returns false outside working hours' do
         expect(in_working_hours?(Time.utc(2019, 12, 26, 7))).to be(false)
         expect(in_working_hours?(Time.utc(2019, 12, 27, 9))).to be(false)
@@ -757,6 +757,20 @@ describe WorkingHours::Computation do
             expect(working_time_between(from, to)).to eq((to - from).round)
           end
         end
+      end
+    end
+
+    context 'with holiday hours' do
+      before do
+        WorkingHours::Config.working_hours = { mon: { '08:00' => '18:00' }, tue: { '08:00' => '18:00' } }
+        WorkingHours::Config.holiday_hours = { '2014-04-07' => { '10:00' => '18:00' } }
+      end
+
+      it 'includes holiday hours' do
+        expect(working_time_between(
+          Time.utc(2014, 4, 7, 8),
+          Time.utc(2014, 4, 7, 9)
+        )).to eq(0)
       end
     end
   end

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -190,12 +190,12 @@ describe WorkingHours::Computation do
       expect(advance_to_working_time(Time.new(2014, 4, 7, 0, 0, 0)).zone).to eq('JST')
     end
 
-<<<<<<< HEAD
     it 'jumps outside holiday hours', :focus do
       WorkingHours::Config.working_hours = { fri: { '08:00' => '18:00' } }
       WorkingHours::Config.holiday_hours = { '2019-12-27' => { '10:00' => '18:00' } }
       expect(advance_to_working_time(Time.utc(2019, 12, 27, 9))).to eq(Time.utc(2019, 12, 27, 10))
-=======
+    end
+
     it 'do not leak nanoseconds when advancing' do
       expect(advance_to_working_time(Time.utc(2014, 4, 7, 5, 0, 0, 123456.789))).to eq(Time.utc(2014, 4, 7, 9, 0, 0, 0))
     end
@@ -224,7 +224,6 @@ describe WorkingHours::Computation do
       # starting from wrong time-zone
       expect(advance_to_working_time(Time.new(2020, 10, 25, 4, 0, 0, "+02:00"))).to eq(Time.new(2020, 10, 25, 9, 0, 0, "+01:00"))
       expect(advance_to_working_time(Time.new(2020, 10, 25, 1, 0, 0, "+01:00"))).to eq(Time.new(2020, 10, 25, 9, 0, 0, "+01:00"))
->>>>>>> upstream/master
     end
   end
 
@@ -329,7 +328,6 @@ describe WorkingHours::Computation do
       expect(advance_to_closing_time(Time.new(2014, 4, 7, 0, 0, 0)).zone).to eq('JST')
     end
 
-<<<<<<< HEAD
     context 'with holiday hours' do
       before do
         WorkingHours::Config.working_hours = { thu: { '08:00' => '18:00' }, fri: { '08:00' => '18:00' } }
@@ -344,7 +342,8 @@ describe WorkingHours::Computation do
         WorkingHours::Config.holiday_hours = { '2019-12-26' => { '10:00' => '21:00' } }
         expect(advance_to_closing_time(Time.new(2019, 12, 26, 20))).to eq(Time.new(2019, 12, 26, 21))
       end
-=======
+    end
+
     it 'do not leak nanoseconds when advancing' do
       expect(advance_to_closing_time(Time.utc(2014, 4, 7, 5, 0, 0, 123456.789))).to eq(Time.utc(2014, 4, 7, 17, 0, 0, 0))
     end
@@ -373,7 +372,6 @@ describe WorkingHours::Computation do
       # starting from wrong time-zone
       expect(advance_to_closing_time(Time.new(2020, 10, 25, 4, 0, 0, "+02:00"))).to eq(Time.new(2020, 10, 25, 17, 0, 0, "+01:00"))
       expect(advance_to_closing_time(Time.new(2020, 10, 25, 1, 0, 0, "+01:00"))).to eq(Time.new(2020, 10, 25, 17, 0, 0, "+01:00"))
->>>>>>> upstream/master
     end
   end
 

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -166,6 +166,23 @@ describe WorkingHours::Computation do
           expect(add_seconds(time, -120)).to eq(Time.utc(2019, 12, 27, 16, 58))
         end
       end
+
+      context 'with an earlier starting time in the second set of hours within a day' do
+        before do
+          WorkingHours::Config.working_hours = { thu: { '08:00' => '18:00' }, fri: { '08:00' => '12:00', '13:00' => '18:00' } }
+          WorkingHours::Config.holiday_hours = { Date.new(2019, 12, 27) => { '08:00' => '12:00', '14:00' => '18:00' } }
+        end
+
+        it 'adds working seconds' do
+          time = Time.utc(2019, 12, 27, 12, 59)
+          expect(add_seconds(time, 120)).to eq(Time.utc(2019, 12, 27, 14, 2))
+        end
+
+        it 'removes working seconds' do
+          time = Time.utc(2019, 12, 27, 14)
+          expect(add_seconds(time, -120)).to eq(Time.utc(2019, 12, 27, 11, 58))
+        end
+      end
     end
 
     it 'honors miliseconds in the base time and increment (but return rounded result)' do

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -211,7 +211,7 @@ describe WorkingHours::Computation do
       expect(advance_to_working_time(Time.new(2014, 4, 7, 0, 0, 0)).zone).to eq('JST')
     end
 
-    it 'jumps outside holiday hours', :focus do
+    it 'jumps outside holiday hours' do
       WorkingHours::Config.working_hours = { fri: { '08:00' => '18:00' } }
       WorkingHours::Config.holiday_hours = { '2019-12-27' => { '10:00' => '18:00' } }
       expect(advance_to_working_time(Time.utc(2019, 12, 27, 9))).to eq(Time.utc(2019, 12, 27, 10))

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -146,10 +146,15 @@ describe WorkingHours::Computation do
       WorkingHours::Config.time_zone = 'Tokyo'
       expect(advance_to_working_time(Time.new(2014, 4, 7, 0, 0, 0)).zone).to eq('JST')
     end
+
+    it 'jumps outside holiday hours', :focus do
+      WorkingHours::Config.working_hours = { fri: { '08:00' => '18:00' } }
+      WorkingHours::Config.holiday_hours = { '2019-12-27' => { '10:00' => '18:00' } }
+      expect(advance_to_working_time(Time.utc(2019, 12, 27, 9))).to eq(Time.utc(2019, 12, 27, 10))
+    end
   end
 
   describe '#advance_to_closing_time' do
-
     it 'jumps non-working day' do
       WorkingHours::Config.holidays = [Date.new(2014, 5, 1)]
       holiday = Time.utc(2014, 5, 1, 12, 0)

--- a/spec/working_hours/config_spec.rb
+++ b/spec/working_hours/config_spec.rb
@@ -390,7 +390,7 @@ describe WorkingHours::Config do
 
     it 'computes an optimized version' do
       expect(subject).to eq({
-          :working_hours => [nil, {32400=>61200}, {32400=>61200}, {32400=>61200}, {32400=>61200}, {32400=>61200}, {}],
+          :working_hours => [{}, {32400=>61200}, {32400=>61200}, {32400=>61200}, {32400=>61200}, {32400=>61200}, {}],
           :holiday_hours => {},
           :holidays => Set.new([]),
           :time_zone => ActiveSupport::TimeZone['UTC']

--- a/spec/working_hours/config_spec.rb
+++ b/spec/working_hours/config_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe WorkingHours::Config do
 
   describe '.working_hours' do
-
     let(:config) { WorkingHours::Config.working_hours }
     let(:config2) { { :mon => { '08:00' => '14:00' } } }
     let(:config3) { { :tue => { '10:00' => '16:00' } } }
@@ -155,7 +154,132 @@ describe WorkingHours::Config do
           1.working.hour.ago
         }.to raise_error(WorkingHours::InvalidConfiguration, 'Invalid type for `mon`: String - must be Hash')
       end
+    end
+  end
 
+  describe '.holiday_hours' do
+    let(:config) { WorkingHours::Config.holiday_hours }
+    let(:config2) { { '2019-12-01' => { '08:00' => '14:00' } } }
+    let(:config3) { { '2019-12-02' => { '10:00' => '16:00' } } }
+
+    it 'has a default config' do
+      expect(config).to be_kind_of(Hash)
+    end
+
+    it 'is thread safe' do
+      expect(WorkingHours::Config.holiday_hours).to eq(config)
+
+      thread = Thread.new do
+        WorkingHours::Config.holiday_hours = config2
+        expect(WorkingHours::Config.holiday_hours).to eq(config2)
+        Thread.stop
+        expect(WorkingHours::Config.holiday_hours).to eq(config2)
+      end
+
+      expect {
+        sleep 0.1 # let the thread begin its execution
+      }.not_to change { WorkingHours::Config.holiday_hours }.from(config)
+
+      expect {
+        WorkingHours::Config.holiday_hours = config3
+      }.to change { WorkingHours::Config.holiday_hours }.from(config).to(config3)
+
+      expect {
+        thread.run
+        thread.join
+      }.not_to change { WorkingHours::Config.holiday_hours }.from(config3)
+    end
+
+    it 'is fiber safe' do
+      expect(WorkingHours::Config.holiday_hours).to eq(config)
+
+      fiber = Fiber.new do
+        WorkingHours::Config.holiday_hours = config2
+        expect(WorkingHours::Config.holiday_hours).to eq(config2)
+        Fiber.yield
+        expect(WorkingHours::Config.holiday_hours).to eq(config2)
+      end
+
+      expect {
+        fiber.resume
+      }.not_to change { WorkingHours::Config.holiday_hours }.from(config)
+
+      expect {
+        WorkingHours::Config.holiday_hours = config3
+      }.to change { WorkingHours::Config.holiday_hours }.from(config).to(config3)
+
+      expect {
+        fiber.resume
+      }.not_to change { WorkingHours::Config.holiday_hours }.from(config3)
+    end
+
+    it 'is initialized from last known global config' do
+      WorkingHours::Config.holiday_hours = {'2019-12-01' => {'08:00' => '14:00'}}
+      Thread.new {
+        expect(WorkingHours::Config.holiday_hours).to match '2019-12-01' => {'08:00' => '14:00'}
+      }.join
+    end
+
+    it 'should support multiple timespan per day' do
+      time_sheet = {'2019-12-01' => {'08:00' => '12:00', '14:00' => '18:00'}}
+      WorkingHours::Config.holiday_hours = time_sheet
+      expect(config).to eq(time_sheet)
+    end
+
+    describe 'validations' do
+      it 'rejects invalid day' do
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => 1, 'aaaaaa' => 2}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid day identifier(s): Must be in the format 'YYYY-MM-DD'")
+      end
+
+      it 'rejects other type than hash' do
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => []}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid type for `2019-12-01`: Array - must be Hash")
+      end
+
+      it 'rejects empty range' do
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => {}}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "No working hours given for day `2019-12-01`")
+      end
+
+      it 'rejects invalid time format' do
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => {'8:0' => '12:00'}}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid time: 8:0 - must be 'HH:MM(:SS)'")
+
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => {'08:00' => '24:10'}}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid time: 24:10 - outside of day")
+      end
+
+      it 'rejects invalid range' do
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => {'12:30' => '12:00'}}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid range: 12:30 => 12:00 - ends before it starts")
+      end
+
+      it 'rejects overlapping range' do
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => {'08:00' => '13:00', '12:00' => '18:00'}}
+        }.to raise_error(WorkingHours::InvalidConfiguration, "Invalid range: 12:00 => 18:00 - overlaps previous range")
+      end
+
+      it 'does not reject out-of-order, non-overlapping ranges' do
+        expect {
+          WorkingHours::Config.holiday_hours = {'2019-12-01' => {'10:00' => '11:00', '08:00' => '09:00'}}
+        }.not_to raise_error
+      end
+
+      it 'raises an error when precompiling if working hours are invalid after assignment' do
+        WorkingHours::Config.holiday_hours = {'2019-12-01' => {'10:00' => '11:00', '08:00' => '09:00'}}
+        WorkingHours::Config.holiday_hours['2019-12-01'] = 'Not correct'
+        expect {
+          1.working.hour.ago
+        }.to raise_error(WorkingHours::InvalidConfiguration, 'Invalid type for `2019-12-01`: String - must be Hash')
+      end
     end
   end
 

--- a/spec/working_hours/config_spec.rb
+++ b/spec/working_hours/config_spec.rb
@@ -267,6 +267,7 @@ describe WorkingHours::Config do
     it 'computes an optimized version' do
       expect(subject).to eq({
           :working_hours => [nil, {32400=>61200}, {32400=>61200}, {32400=>61200}, {32400=>61200}, {32400=>61200}],
+          :holiday_hours => {},
           :holidays => Set.new([]),
           :time_zone => ActiveSupport::TimeZone['UTC']
         })
@@ -276,6 +277,7 @@ describe WorkingHours::Config do
       WorkingHours::Config.working_hours = {:mon => {'20:32:59' => '22:59:59'}}
       expect(subject).to eq({
         :working_hours => [nil, {73979 => 82799}],
+        :holiday_hours => {},
         :holidays => Set.new([]),
         :time_zone => ActiveSupport::TimeZone['UTC']
       })
@@ -285,6 +287,7 @@ describe WorkingHours::Config do
       WorkingHours::Config.working_hours = {:mon => {'20:00' => '24:00'}}
       expect(subject).to eq({
         :working_hours => [nil, {72000 => 86399.999999}],
+        :holiday_hours => {},
         :holidays => Set.new([]),
         :time_zone => ActiveSupport::TimeZone['UTC']
       })


### PR DESCRIPTION
Unsure if this is useful for many people using this gem, however we had a recent need to set specific working hours during "holiday season" - e.g. over Christmas we'd like our working hours to be slightly different to our regular hours.

I've introduced a new config option here `holiday_hours` that's a hash of dates (in the string format `YYYY-MM-DD`, that behaves in a very similar way to `working_hours`, in that each key takes a hash of start times (e.g. it can still support multiple times within 1 day).

No worries if this isn't the direction you'd like this gem to take, just thought I'd share some code that was helpful to us - thanks for an excellent gem!