### PR TITLE
Fix : day computation when origin is either a holiday or a non worked day

### DIFF
--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -5,6 +5,8 @@ module WorkingHours
   module Computation
 
     def add_days origin, days, config: nil
+      return origin if days.zero?
+
       config ||= wh_config
       time = in_config_zone(origin, config: config)
       time += (days <=> 0).day until working_day?(time, config: config)

--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -7,6 +7,8 @@ module WorkingHours
     def add_days origin, days, config: nil
       config ||= wh_config
       time = in_config_zone(origin, config: config)
+      time += (days <=> 0).day until working_day?(time, config: config)
+
       while days > 0
         time += 1.day
         days -= 1 if working_day?(time, config: config)

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -32,10 +32,24 @@ describe WorkingHours::Computation do
       expect(add_days(time, 1)).to eq(Date.new(2014, 4, 9)) # Wednesday
     end
 
+    it 'skips non worked days when origin is not worked' do
+      time = Date.new(2014, 4, 8) # Tuesday
+      WorkingHours::Config.working_hours = {mon: {'09:00' => '17:00'}, wed: {'09:00' => '17:00'}, thu: {'09:00' => '17:00'}, sun: {'09:00' => '17:00'}}
+      expect(add_days(time, 1)).to eq(Date.new(2014, 4, 10)) # Wednesday
+      expect(add_days(time, -1)).to eq(Date.new(2014, 4, 6)) # Sunday
+    end
+
     it 'skips holidays' do
       time = Date.new(2014, 4, 7) # Monday
       WorkingHours::Config.holidays = [Date.new(2014, 4, 8)] # Tuesday
       expect(add_days(time, 1)).to eq(Date.new(2014, 4, 9)) # Wednesday
+    end
+
+    it 'skips holidays when origin is holiday' do
+      time = Date.new(2014, 4, 9) # Wednesday
+      WorkingHours::Config.holidays = [time] # Wednesday
+      expect(add_days(time, 1)).to eq(Date.new(2014, 4, 11)) # Thursday
+      expect(add_days(time, -1)).to eq(Date.new(2014, 4, 7)) # Monday
     end
 
     it 'skips holidays and non worked days' do

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -35,7 +35,7 @@ describe WorkingHours::Computation do
     it 'skips non worked days when origin is not worked' do
       time = Date.new(2014, 4, 8) # Tuesday
       WorkingHours::Config.working_hours = {mon: {'09:00' => '17:00'}, wed: {'09:00' => '17:00'}, thu: {'09:00' => '17:00'}, sun: {'09:00' => '17:00'}}
-      expect(add_days(time, 1)).to eq(Date.new(2014, 4, 10)) # Wednesday
+      expect(add_days(time, 1)).to eq(Date.new(2014, 4, 10)) # Thursday
       expect(add_days(time, -1)).to eq(Date.new(2014, 4, 6)) # Sunday
     end
 
@@ -48,7 +48,7 @@ describe WorkingHours::Computation do
     it 'skips holidays when origin is holiday' do
       time = Date.new(2014, 4, 9) # Wednesday
       WorkingHours::Config.holidays = [time] # Wednesday
-      expect(add_days(time, 1)).to eq(Date.new(2014, 4, 11)) # Thursday
+      expect(add_days(time, 1)).to eq(Date.new(2014, 4, 11)) # Friday
       expect(add_days(time, -1)).to eq(Date.new(2014, 4, 7)) # Monday
     end
 

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -59,6 +59,12 @@ describe WorkingHours::Computation do
       expect(add_days(time, 3)).to eq(Date.new(2014, 4, 21))
     end
 
+    it 'returns the original value when adding 0 days' do
+      time = Date.new(2014, 4, 7)
+      WorkingHours::Config.holidays = [time]
+      expect(add_days(time, 0)).to eq(time)
+    end
+
     it 'accepts time given from any time zone' do
       time = Time.utc(1991, 11, 14, 21, 0, 0) # Thursday 21 pm UTC
       WorkingHours::Config.time_zone = 'Tokyo' # But we are at tokyo, so it's already Friday 6 am


### PR DESCRIPTION
cf #38
 
When the origin is a holiday or a non worked day, adding days to it doesn't behave as expected.

Fix :  `advance_to_working_time` if the current day is not a `working_day?`

I'm not sure if this is exactly what we want or if the current implementation is ok, would love a second opinion