### PR TITLE
Reduce rounding imprecisions (fixes #42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
-[Compare master with v1.2.0](https://github.com/intrepidd/working_hours/compare/v1.2.0...master)
+[Compare master with v1.3.0](https://github.com/intrepidd/working_hours/compare/v1.3.0...master)
+
+# v1.3.0
+* Improve supports for fractional seconds in input times by only rounding results at the end - [#42](https://github.com/Intrepidd/working_hours/issues/42) [#43](https://github.com/Intrepidd/working_hours/pull/43)
 
 # v1.2.0
 * Drop support for ruby 2.0, 2.1, 2.2 and 2.3

--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -34,7 +34,7 @@ module WorkingHours
 
     def add_seconds origin, seconds, config: nil
       config ||= wh_config
-      time = in_config_zone(origin, config: config).round
+      time = in_config_zone(origin, config: config)
       while seconds > 0
         # roll to next business period
         time = advance_to_working_time(time, config: config)
@@ -72,7 +72,7 @@ module WorkingHours
 
     def advance_to_working_time time, config: nil
       config ||= wh_config
-      time = in_config_zone(time, config: config).round
+      time = in_config_zone(time, config: config)
       loop do
         # skip holidays and weekends
         while not working_day?(time, config: config)
@@ -91,7 +91,7 @@ module WorkingHours
 
     def advance_to_closing_time time, config: nil
       config ||= wh_config
-      time = in_config_zone(time, config: config).round
+      time = in_config_zone(time, config: config)
       loop do
         # skip holidays and weekends
         while not working_day?(time, config: config)
@@ -123,7 +123,7 @@ module WorkingHours
 
     def return_to_exact_working_time time, config: nil
       config ||= wh_config
-      time = in_config_zone(time, config: config).round
+      time = in_config_zone(time, config: config)
       loop do
         # skip holidays and weekends
         while not working_day?(time, config: config)
@@ -180,7 +180,7 @@ module WorkingHours
         -working_time_between(to, from, config: config)
       else
         from = advance_to_working_time(in_config_zone(from, config: config))
-        to = in_config_zone(to, config: config).round
+        to = in_config_zone(to, config: config)
         distance = 0
         while from < to
           # look at working ranges

--- a/lib/working_hours/version.rb
+++ b/lib/working_hours/version.rb
@@ -1,3 +1,3 @@
 module WorkingHours
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
Ok I had a look at #42, so far it seems OK, I removed some `round`, added some specs (which are red on master) and didn't break any other. I checked if some of the methods I modified could be negatively impacted by suddenly having times with usec but I didn't find any reason. @Intrepidd what do you think? 