### PR TITLE
Improve computation accuracy + add protection against infinite loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .ruby-gemset
 .ruby-version
 Gemfile.lock
+gemfiles/*.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
+dist: bionic
 rvm:
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
-  - 2.7.0
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.2
   - 3.0.0
   - jruby-9.2.14.0
 gemfile:
@@ -12,16 +13,14 @@ gemfile:
   - gemfiles/Gemfile.activesupport-6.x
 jobs:
   exclude:
-    - rvm: 2.4.9
+    - rvm: 2.4.10
       gemfile: gemfiles/Gemfile.activesupport-6.x
-    - rvm: 2.7.0
+    - rvm: 2.7.2
       gemfile: gemfiles/Gemfile.activesupport-4.x
     - rvm: 3.0.0
       gemfile: gemfiles/Gemfile.activesupport-4.x
   include:
     - rvm: ruby-head
-      gemfile: gemfiles/Gemfile.activesupport-edge
-    - rvm: jruby-head
       gemfile: gemfiles/Gemfile.activesupport-edge
   allow_failures:
     - gemfile: gemfiles/Gemfile.activesupport-edge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Unreleased
 
-[Compare master with v1.3.0](https://github.com/intrepidd/working_hours/compare/v1.3.0...master)
+[Compare master with v1.3.1](https://github.com/intrepidd/working_hours/compare/v1.3.1...master)
+
+# v1.3.1
+* Improve computation accuracy in `advance_to_working_time` and `working_time_between` by using more exact (integer-based) time operations instead of floating point numbers - [#44](https://github.com/Intrepidd/working_hours/pull/44)
+* Raise an exception when we detect an infinite loops in `advance_to_working_time` to improve resilience and make debugging easier - [#44](https://github.com/Intrepidd/working_hours/pull/44)
+* Use a Rational number for the midnight value to avoid leaking sub-nanoseconds residue because of floating point accuracy - [#44](https://github.com/Intrepidd/working_hours/pull/44)
 
 # v1.3.0
 * Improve supports for fractional seconds in input times by only rounding results at the end - [#42](https://github.com/Intrepidd/working_hours/issues/42) [#43](https://github.com/Intrepidd/working_hours/pull/43)

--- a/gemfiles/Gemfile.activesupport-6.x
+++ b/gemfiles/Gemfile.activesupport-6.x
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec :path => '..'
 
-gem 'activesupport', '~> 6.0'
+gem 'activesupport', '~> 6.1'

--- a/gemfiles/Gemfile.activesupport-edge
+++ b/gemfiles/Gemfile.activesupport-edge
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec :path => '..'
 
-gem 'activesupport', github: 'rails/rails'
+gem 'activesupport', github: 'rails/rails', branch: 'main'

--- a/lib/working_hours/config.rb
+++ b/lib/working_hours/config.rb
@@ -7,6 +7,7 @@ module WorkingHours
 
     TIME_FORMAT = /\A([0-2][0-9])\:([0-5][0-9])(?:\:([0-5][0-9]))?\z/
     DAYS_OF_WEEK = [:sun, :mon, :tue, :wed, :thu, :fri, :sat]
+    MIDNIGHT = Rational('86399.999999')
 
     class << self
 
@@ -115,7 +116,7 @@ module WorkingHours
         sec = time[TIME_FORMAT,3].to_i
         time = hour * 3600 + min * 60 + sec
         # Converts 24:00 to 23:59:59.999999
-        return 86399.999999 if time == 86400
+        return MIDNIGHT if time == 86400
         time
       end
 

--- a/lib/working_hours/version.rb
+++ b/lib/working_hours/version.rb
@@ -1,3 +1,3 @@
 module WorkingHours
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -261,6 +261,7 @@ describe WorkingHours::Computation do
       end
 
       it 'give precise computation with nothing other than miliseconds' do
+        pending "iso8601 is not precise enough on AS < 4" if ActiveSupport::VERSION::MAJOR <= 4
         expect(advance_to_closing_time(monday_morning).iso8601(25)).to eq("2014-04-07T23:59:59.9999990000000000000000000Z")
       end
     end
@@ -574,7 +575,7 @@ describe WorkingHours::Computation do
       expect { working_time_between(
         Time.utc(2014, 4, 7, 5, 0, 0),
         Time.utc(2014, 4, 7, 15, 0, 0),
-      ) }.to raise_error(RuntimeError, /Invalid loop detected in working_time_between \(from=2014-04-07T08:59:59.999899999999Z, to=2014-04-07T15:00:00.000000000000Z, distance=0, config=/)
+      ) }.to raise_error(RuntimeError, /Invalid loop detected in working_time_between \(from=2014-04-07T08:59:59.999/)
     end
 
     # generates two times with +0ms, +250ms, +500ms, +750ms and +1s

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -173,6 +173,10 @@ describe WorkingHours::Computation do
       WorkingHours::Config.time_zone = 'Tokyo'
       expect(advance_to_working_time(Time.new(2014, 4, 7, 0, 0, 0)).zone).to eq('JST')
     end
+
+    it 'do not leak nanoseconds when advancing' do
+      expect(advance_to_working_time(Time.utc(2014, 4, 7, 5, 0, 0, 123456.789))).to eq(Time.utc(2014, 4, 7, 9, 0, 0, 0))
+    end
   end
 
   describe '#advance_to_closing_time' do
@@ -240,7 +244,7 @@ describe WorkingHours::Computation do
       end
 
       let(:monday_morning) { Time.utc(2014, 4, 7, 0) }
-      let(:monday_closing) { Time.utc(2014, 4, 7) + 86399.999999 }
+      let(:monday_closing) { Time.utc(2014, 4, 7) + WorkingHours::Config::MIDNIGHT }
       let(:tuesday_closing) { Time.utc(2014, 4, 8, 17) }
       let(:sunday) { Time.utc(2014, 4, 6, 17) }
 
@@ -254,6 +258,10 @@ describe WorkingHours::Computation do
 
       it 'moves over midnight' do
         expect(advance_to_closing_time(sunday)).to eq(monday_closing)
+      end
+
+      it 'give precise computation with nothing other than miliseconds' do
+        expect(advance_to_closing_time(monday_morning).iso8601(25)).to eq("2014-04-07T23:59:59.9999990000000000000000000Z")
       end
     end
 
@@ -270,6 +278,10 @@ describe WorkingHours::Computation do
     it 'returns time in config zone' do
       WorkingHours::Config.time_zone = 'Tokyo'
       expect(advance_to_closing_time(Time.new(2014, 4, 7, 0, 0, 0)).zone).to eq('JST')
+    end
+
+    it 'do not leak nanoseconds when advancing' do
+      expect(advance_to_closing_time(Time.utc(2014, 4, 7, 5, 0, 0, 123456.789))).to eq(Time.utc(2014, 4, 7, 17, 0, 0, 0))
     end
   end
 
@@ -542,6 +554,27 @@ describe WorkingHours::Computation do
         Time.new(2014, 4, 7, 1, 0, 0, "-09:00"), # Monday 10am in UTC
         Time.new(2014, 4, 7, 15, 0, 0, "-04:00"), # Monday 7pm in UTC
       )).to eq(7.hours)
+    end
+
+    it 'uses precise computation to avoid useless loops' do
+      # +200 usec on each time, using floating point would cause
+      # precision issues and require several iterations
+      expect(self).to receive(:advance_to_working_time).twice.and_call_original
+      expect(working_time_between(
+        Time.utc(2014, 4, 7, 5, 0, 0, 200),
+        Time.utc(2014, 4, 7, 15, 0, 0, 200),
+      )).to eq(6.hours)
+    end
+
+    it 'do not cause infinite loop if the time is not advancing properly' do
+      # simulate some computation/precision error
+      expect(self).to receive(:advance_to_working_time).twice do |time|
+        time.change(hour: 9) - 0.0001
+      end
+      expect { working_time_between(
+        Time.utc(2014, 4, 7, 5, 0, 0),
+        Time.utc(2014, 4, 7, 15, 0, 0),
+      ) }.to raise_error(RuntimeError, /Invalid loop detected in working_time_between \(from=2014-04-07T08:59:59.999899999999Z, to=2014-04-07T15:00:00.000000000000Z, distance=0, config=/)
     end
 
     # generates two times with +0ms, +250ms, +500ms, +750ms and +1s


### PR DESCRIPTION
Hey :wave: 

I believed we had again in production one of the most feared problem: an infinite loop. We're not certain it comes from `working_hour` but we're pretty sure. And considering I recently removed some rounding it's possible this bug was hidden before.

In this MR I had a look a different things which could cause infinite loops and took the following actions:
* Improve computation accuracy in `advance_to_working_time` and `working_time_between` by using more exact (integer-based) time operations instead of floating point numbers
* Raise an exception when we detect an infinite loops in `advance_to_working_time` to improve resilience and make debugging easier
* Use a Rational number for the midnight value to avoid leaking sub-nanoseconds residue because of floating point accuracy

I believe these should help (or they can't hurt). Let me know what you think @Intrepidd 