### PR TITLE
Better time shift handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Compare master with v1.3.1](https://github.com/intrepidd/working_hours/compare/v1.3.1...master)
 
+# v1.3.2
+* Improve support for time shifts - [#46](https://github.com/Intrepidd/working_hours/pull/46)
+
 # v1.3.1
 * Improve computation accuracy in `advance_to_working_time` and `working_time_between` by using more exact (integer-based) time operations instead of floating point numbers - [#44](https://github.com/Intrepidd/working_hours/pull/44)
 * Raise an exception when we detect an infinite loops in `advance_to_working_time` to improve resilience and make debugging easier - [#44](https://github.com/Intrepidd/working_hours/pull/44)

--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -213,6 +213,7 @@ module WorkingHours
     #   time.beginning_of_day + seconds
     # (because this one would shift hours during time shifts days)
     def move_time_of_day time, seconds
+      # return time.beginning_of_day + seconds
       hour = (seconds / 3600).to_i
       seconds %= 3600
       minutes = (seconds / 60).to_i

--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -217,7 +217,9 @@ module WorkingHours
       seconds %= 3600
       minutes = (seconds / 60).to_i
       seconds %= 60
-      time.change(hour: hour, min: minutes, sec: seconds)
+      # sec/usec separation is required for ActiveSupport <= 5.1
+      usec = ((seconds % 1) * 10**6)
+      time.change(hour: hour, min: minutes, sec: seconds.to_i, usec: usec)
     end
 
     def wh_config

--- a/lib/working_hours/computation.rb
+++ b/lib/working_hours/computation.rb
@@ -82,7 +82,7 @@ module WorkingHours
         time_in_day = time.seconds_since_midnight
         config[:working_hours][time.wday].each do |from, to|
           return time if time_in_day >= from and time_in_day < to
-          return time.beginning_of_day + from if from >= time_in_day
+          return move_time_of_day(time, from) if from >= time_in_day
         end
         # if none is found, go to next day and loop
         time = (time + 1.day).beginning_of_day
@@ -99,12 +99,11 @@ module WorkingHours
         end
         # find next working range after time
         time_in_day = time.seconds_since_midnight
-        time = time.beginning_of_day
         config[:working_hours][time.wday].each do |from, to|
-          return time + to if time_in_day < to
+          return move_time_of_day(time, to) if time_in_day < to
         end
         # if none is found, go to next day and loop
-        time = time + 1.day
+        time = (time + 1.day).beginning_of_day
       end
     end
 
@@ -131,9 +130,8 @@ module WorkingHours
         # find last working range before time
         time_in_day = time.seconds_since_midnight
         config[:working_hours][time.wday].reverse_each do |from, to|
-          # round is used to suppress miliseconds hack from `end_of_day`
           return time if time_in_day > from and time_in_day <= to
-          return (time - (time_in_day - to)) if to <= time_in_day
+          return move_time_of_day(time, to) if to <= time_in_day
         end
         # if none is found, go to previous day and loop
         time = (time - 1.day).end_of_day
@@ -190,7 +188,7 @@ module WorkingHours
               if (to - from) > (ends - time_in_day)
                 # take all the range and continue
                 distance += (ends - time_in_day)
-                from = from.beginning_of_day + ends
+                from = move_time_of_day(from, ends)
               else
                 # take only what's needed and stop
                 distance += (to - from)
@@ -207,6 +205,20 @@ module WorkingHours
     end
 
     private
+
+    # Changes the time of the day to match given time (in seconds since midnight)
+    # preserving nanosecond prevision (rational number) and honoring time shifts
+    #
+    # This replaces the previous implementation which was:
+    #   time.beginning_of_day + seconds
+    # (because this one would shift hours during time shifts days)
+    def move_time_of_day time, seconds
+      hour = (seconds / 3600).to_i
+      seconds %= 3600
+      minutes = (seconds / 60).to_i
+      seconds %= 60
+      time.change(hour: hour, min: minutes, sec: seconds)
+    end
 
     def wh_config
       WorkingHours::Config.precompiled

--- a/lib/working_hours/version.rb
+++ b/lib/working_hours/version.rb
@@ -1,3 +1,3 @@
 module WorkingHours
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -663,6 +663,15 @@ describe WorkingHours::Computation do
       )).to eq(13.hours)
     end
 
+    it 'works across time shifts + midnight' do
+      WorkingHours::Config.working_hours = {sun: {'00:00' => '24:00'}}
+      WorkingHours::Config.time_zone = 'Paris'
+      expect(working_time_between(
+        Time.utc(2020, 10, 24, 22, 0),
+        Time.utc(2020, 10, 25, 23, 0),
+      )).to eq(24.hours)
+    end
+
     it 'works across multiple time shifts' do
       WorkingHours::Config.working_hours = {sun: {'08:00' => '21:00'}}
       WorkingHours::Config.time_zone = 'Paris'

--- a/spec/working_hours/computation_spec.rb
+++ b/spec/working_hours/computation_spec.rb
@@ -177,6 +177,32 @@ describe WorkingHours::Computation do
     it 'do not leak nanoseconds when advancing' do
       expect(advance_to_working_time(Time.utc(2014, 4, 7, 5, 0, 0, 123456.789))).to eq(Time.utc(2014, 4, 7, 9, 0, 0, 0))
     end
+
+    it 'returns correct hour during positive time shifts' do
+      WorkingHours::Config.working_hours = {sun: {'09:00' => '17:00'}}
+      WorkingHours::Config.time_zone = 'Paris'
+      from = Time.new(2020, 3, 29, 0, 0, 0, "+01:00")
+      expect(from.utc_offset).to eq(3600)
+      res = advance_to_working_time(from)
+      expect(res).to eq(Time.new(2020, 3, 29, 9, 0, 0, "+02:00"))
+      expect(res.utc_offset).to eq(7200)
+      # starting from wrong time-zone
+      expect(advance_to_working_time(Time.new(2020, 3, 29, 5, 0, 0, "+01:00"))).to eq(Time.new(2020, 3, 29, 9, 0, 0, "+02:00"))
+      expect(advance_to_working_time(Time.new(2020, 3, 29, 1, 0, 0, "+02:00"))).to eq(Time.new(2020, 3, 29, 9, 0, 0, "+02:00"))
+    end
+
+    it 'returns correct hour during negative time shifts' do
+      WorkingHours::Config.working_hours = {sun: {'09:00' => '17:00'}}
+      WorkingHours::Config.time_zone = 'Paris'
+      from = Time.new(2020, 10, 25, 0, 0, 0, "+02:00")
+      expect(from.utc_offset).to eq(7200)
+      res = advance_to_working_time(from)
+      expect(res).to eq(Time.new(2020, 10, 25, 9, 0, 0, "+01:00"))
+      expect(res.utc_offset).to eq(3600)
+      # starting from wrong time-zone
+      expect(advance_to_working_time(Time.new(2020, 10, 25, 4, 0, 0, "+02:00"))).to eq(Time.new(2020, 10, 25, 9, 0, 0, "+01:00"))
+      expect(advance_to_working_time(Time.new(2020, 10, 25, 1, 0, 0, "+01:00"))).to eq(Time.new(2020, 10, 25, 9, 0, 0, "+01:00"))
+    end
   end
 
   describe '#advance_to_closing_time' do
@@ -284,6 +310,32 @@ describe WorkingHours::Computation do
     it 'do not leak nanoseconds when advancing' do
       expect(advance_to_closing_time(Time.utc(2014, 4, 7, 5, 0, 0, 123456.789))).to eq(Time.utc(2014, 4, 7, 17, 0, 0, 0))
     end
+
+    it 'returns correct hour during positive time shifts' do
+      WorkingHours::Config.working_hours = {sun: {'09:00' => '17:00'}}
+      WorkingHours::Config.time_zone = 'Paris'
+      from = Time.new(2020, 3, 29, 0, 0, 0, "+01:00")
+      expect(from.utc_offset).to eq(3600)
+      res = advance_to_closing_time(from)
+      expect(res).to eq(Time.new(2020, 3, 29, 17, 0, 0, "+02:00"))
+      expect(res.utc_offset).to eq(7200)
+      # starting from wrong time-zone
+      expect(advance_to_closing_time(Time.new(2020, 3, 29, 5, 0, 0, "+01:00"))).to eq(Time.new(2020, 3, 29, 17, 0, 0, "+02:00"))
+      expect(advance_to_closing_time(Time.new(2020, 3, 29, 1, 0, 0, "+02:00"))).to eq(Time.new(2020, 3, 29, 17, 0, 0, "+02:00"))
+    end
+
+    it 'returns correct hour during negative time shifts' do
+      WorkingHours::Config.working_hours = {sun: {'09:00' => '17:00'}}
+      WorkingHours::Config.time_zone = 'Paris'
+      from = Time.new(2020, 10, 25, 0, 0, 0, "+02:00")
+      expect(from.utc_offset).to eq(7200)
+      res = advance_to_closing_time(from)
+      expect(res).to eq(Time.new(2020, 10, 25, 17, 0, 0, "+01:00"))
+      expect(res.utc_offset).to eq(3600)
+      # starting from wrong time-zone
+      expect(advance_to_closing_time(Time.new(2020, 10, 25, 4, 0, 0, "+02:00"))).to eq(Time.new(2020, 10, 25, 17, 0, 0, "+01:00"))
+      expect(advance_to_closing_time(Time.new(2020, 10, 25, 1, 0, 0, "+01:00"))).to eq(Time.new(2020, 10, 25, 17, 0, 0, "+01:00"))
+    end
   end
 
   describe '#next_working_time' do
@@ -389,6 +441,32 @@ describe WorkingHours::Computation do
     it 'returns time in config zone' do
       WorkingHours::Config.time_zone = 'Tokyo'
       expect(return_to_working_time(Time.new(2014, 4, 7, 1, 0, 0)).zone).to eq('JST')
+    end
+
+    it 'returns correct hour during positive time shifts' do
+      WorkingHours::Config.working_hours = {sun: {'00:00' => '01:00'}}
+      WorkingHours::Config.time_zone = 'Paris'
+      from = Time.new(2020, 3, 29, 9, 0, 0, "+02:00")
+      expect(from.utc_offset).to eq(7200)
+      res = return_to_working_time(from)
+      expect(res).to eq(Time.new(2020, 3, 29, 1, 0, 0, "+01:00"))
+      expect(res.utc_offset).to eq(3600)
+      # starting from wrong time-zone
+      expect(return_to_working_time(Time.new(2020, 3, 29, 2, 0, 0, "+02:00"))).to eq(Time.new(2020, 3, 29, 1, 0, 0, "+01:00"))
+      expect(return_to_working_time(Time.new(2020, 3, 29, 9, 0, 0, "+01:00"))).to eq(Time.new(2020, 3, 29, 1, 0, 0, "+01:00"))
+    end
+
+    it 'returns correct hour during negative time shifts' do
+      WorkingHours::Config.working_hours = {sun: {'00:00' => '01:00'}}
+      WorkingHours::Config.time_zone = 'Paris'
+      from = Time.new(2020, 10, 25, 9, 0, 0, "+01:00")
+      expect(from.utc_offset).to eq(3600)
+      res = return_to_working_time(from)
+      expect(res).to eq(Time.new(2020, 10, 25, 1, 0, 0, "+02:00"))
+      expect(res.utc_offset).to eq(7200)
+      # starting from wrong time-zone
+      expect(return_to_working_time(Time.new(2020, 10, 25, 9, 0, 0, "+02:00"))).to eq(Time.new(2020, 10, 25, 1, 0, 0, "+02:00"))
+      expect(return_to_working_time(Time.new(2020, 10, 25, 1, 0, 0, "+01:00"))).to eq(Time.new(2020, 10, 25, 1, 0, 0, "+02:00"))
     end
   end
 
@@ -565,6 +643,33 @@ describe WorkingHours::Computation do
         Time.utc(2014, 4, 7, 5, 0, 0, 200),
         Time.utc(2014, 4, 7, 15, 0, 0, 200),
       )).to eq(6.hours)
+    end
+
+    it 'works across positive time shifts' do
+      WorkingHours::Config.working_hours = {sun: {'08:00' => '21:00'}}
+      WorkingHours::Config.time_zone = 'Paris'
+      expect(working_time_between(
+        Time.utc(2020, 3, 29, 1, 0),
+        Time.utc(2020, 3, 30, 0, 0),
+      )).to eq(13.hours)
+    end
+
+    it 'works across negative time shifts' do
+      WorkingHours::Config.working_hours = {sun: {'08:00' => '21:00'}}
+      WorkingHours::Config.time_zone = 'Paris'
+      expect(working_time_between(
+        Time.utc(2019, 10, 27, 1, 0),
+        Time.utc(2019, 10, 28, 0, 0),
+      )).to eq(13.hours)
+    end
+
+    it 'works across multiple time shifts' do
+      WorkingHours::Config.working_hours = {sun: {'08:00' => '21:00'}}
+      WorkingHours::Config.time_zone = 'Paris'
+      expect(working_time_between(
+        Time.utc(2002, 10, 27, 6, 0),
+        Time.utc(2021, 10, 30, 0, 0),
+      )).to eq(12896.hours)
     end
 
     it 'do not cause infinite loop if the time is not advancing properly' do


### PR DESCRIPTION
Turns out the new "Invalid loop" exception raised sooner than expected :) and it was because of time shifts... Fortunately I was able to reproduce the problem easily and write some specs. So here is the better support for time shift (closing #45).

I think it's not complete yet, we would still have problems with `seconds_since_midnight` returning absolute time difference which may cause subtle difference/bugs on the day of the shift. But at least the basics is here and now it can cross time shifts without raising ;)