### PR TITLE
Better: Add InvalidConfiguration error code to allow custom message or behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,6 @@ rescue WorkingHours::InvalidConfiguration => e
 end
 ```
 
-
-
-
-
-
 ## No core extensions / monkey patching
 
 Core extensions (monkey patching to add methods on Time, Date, Numbers, etc.) are handy but not appreciated by everyone. WorkingHours can also be used **without any monkey patching**:

--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ There is a gem called [business_time](https://github.com/bokmann/business_time) 
 
 Another gem called [biz](https://github.com/zendesk/biz) was released after working_hours to bring some alternative.
 
-
 ## Contributing
 
 1. Fork it ( http://github.com/intrepidd/working_hours/fork )

--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ You can also access the error code in case you want to implement custom behavior
 
 ```ruby
 rescue WorkingHours::InvalidConfiguration => e
-    if e.error_code == :empty
-      raise StandardError.new "Config is required"
-    end
-    raise e
+  if e.error_code == :empty
+    raise StandardError.new "Config is required"
+  end
+  raise e
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,26 @@ If *any* hours are set for a calendar day in `holiday_hours`, then the `working_
 WorkingHours::Config.holiday_hours = {Date.new(2020, 12, 24) => {'09:00' => '12:00', '13:00' => '15:00'}}
 ```
 
+### Handling errors
+
+If the configuration is erroneous, an ``WorkingHours::InvalidConfiguration`` exception will be raised containing the appropriate error message.
+
+You can also access the error code in case you want to implement custom behavior or changing one specific message, e.g:
+
+```ruby
+rescue WorkingHours::InvalidConfiguration => e
+    if e.error_code == :empty
+      raise StandardError.new "Config is required"
+    end
+    raise e
+end
+```
+
+
+
+
+
+
 ## No core extensions / monkey patching
 
 Core extensions (monkey patching to add methods on Time, Date, Numbers, etc.) are handy but not appreciated by everyone. WorkingHours can also be used **without any monkey patching**:
@@ -186,6 +206,7 @@ This gem uses a simple but efficient approach in dealing with timezones. When yo
 There is a gem called [business_time](https://github.com/bokmann/business_time) already available to do this kind of computation and it was of great help to us. But we decided to start another one because business_time is suffering from a few [bugs](https://github.com/bokmann/business_time/pull/84) and [inconsistencies](https://github.com/bokmann/business_time/issues/50). It also lacks essential features to us (like working minutes computation).
 
 Another gem called [biz](https://github.com/zendesk/biz) was released after working_hours to bring some alternative.
+
 
 ## Contributing
 

--- a/lib/working_hours/config.rb
+++ b/lib/working_hours/config.rb
@@ -4,8 +4,8 @@ module WorkingHours
   class InvalidConfiguration < StandardError
     attr_reader :data, :error_code
 
-    def initialize(error_code, data: {})
-      @data = data unless data.blank?
+    def initialize(error_code, data: nil)
+      @data = data
       @error_code = error_code
       super compose_message(error_code)
     end


### PR DESCRIPTION
Hey !

- Ticket(s): RD-18471 (that's for @CedricBm)

In the effort of translating our application, we would like to be able to translate the error messages raised when configuration is invalid.

What I propose is to have a `InvalidConfiguration.error_code` indicating what is the error along with `InvalidConfiguration.data` containing the data related to the error.

I hesitated storing the whole record inside the error, it would make accessing the data simpler but it seemed like a waste of storage - might be irrelevant since it's a pointer. Anyway let me know if you disagree.

By the way, I can confirm all the messages have a corresponding spec so I didn't have to add any.